### PR TITLE
Support Async Handlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -337,9 +337,9 @@ export interface AuthResponseContext {
  * @param context – runtime information of the Lambda function that is executing.
  * @param callback – optional callback to return information to the caller, otherwise return value is null.
  */
-export type Handler = (event: any, context: Context, callback?: Callback) => void;
-export type ProxyHandler = (event: APIGatewayEvent, context: Context, callback?: ProxyCallback) => void;
-export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Context, callback?: CustomAuthorizerCallback) => void;
+export type Handler = (event: any, context: Context, callback?: Callback) => Promise<any> | void;
+export type ProxyHandler = (event: APIGatewayEvent, context: Context, callback?: ProxyCallback) => Promise<ProxyResult> | void;
+export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Context, callback?: CustomAuthorizerCallback) => Promise<AuthResponse> |void;
 
 /**
  * Optional callback parameter.

--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ export interface AuthResponseContext {
  */
 export type Handler = (event: any, context: Context, callback?: Callback) => Promise<any> | void;
 export type ProxyHandler = (event: APIGatewayEvent, context: Context, callback?: ProxyCallback) => Promise<ProxyResult> | void;
-export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Context, callback?: CustomAuthorizerCallback) => Promise<AuthResponse> |void;
+export type CustomAuthorizerHandler = (event: CustomAuthorizerEvent, context: Context, callback?: CustomAuthorizerCallback) => Promise<AuthResponse> | void;
 
 /**
  * Optional callback parameter.


### PR DESCRIPTION
Support handlers returning Promises for use with node >8.10 runtime per https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html