### PR TITLE
Authorizer property into requestContext & generic type for body

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // API Gateway "event"
-export type APIGatewayEvent = {
-    body: null;
+export type APIGatewayEvent<T = string> = {
+    body: T | null;
     headers: { [name: string]: string };
     httpMethod: string;
     isBase64Encoded: boolean;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 
 // API Gateway "event"
 export type APIGatewayEvent = {
-    body: string | null;
+    body: null;
     headers: { [name: string]: string };
     httpMethod: string;
     isBase64Encoded: boolean;
@@ -17,6 +17,7 @@ export type APIGatewayEvent = {
     requestContext: {
         accountId: string;
         apiId: string;
+        authorizer?: AuthResponseContext | any;
         httpMethod: string;
         identity: {
             accessKey: string | null;


### PR DESCRIPTION
Just added support of optional authorizer into requestContext.
Also, I'm using a middleware to automatically parse the body so it's already an object and not a string.
I propose to use a generic type with default string. Another option would be an object definition.